### PR TITLE
Fix mask issue in BorderBrush

### DIFF
--- a/engenious.UI/BorderBrush.cs
+++ b/engenious.UI/BorderBrush.cs
@@ -116,7 +116,7 @@ namespace engenious.UI
                 case LineType.Solid:
                     buffer = new Color[LineWidth * LineWidth];
                     for (int i = 0; i < buffer.Length; i++)
-                        buffer[i] = LineColor;
+                        buffer[i] = Color.White;
                     tex = new Texture2D(Skin.Pix.GraphicsDevice, LineWidth, LineWidth);
                     tex.SetData(buffer);
                     MinWidth = MinHeight = (LineWidth * 2) + 1;


### PR DESCRIPTION
Because the texture is used as a mask (see Dotted)  we should not use the LineColor in the data array of the texture. With this fix the solid lines should be visible now