### PR TITLE
Makes `BaseScreenComponent` optional

### DIFF
--- a/SampleClient/SampleClient.csproj
+++ b/SampleClient/SampleClient.csproj
@@ -24,7 +24,7 @@
       <None Remove="Content\obj\**" />
     </ItemGroup>
     <ItemGroup>
-<!--      <PackageReference Include="engenious.ContentTool" Version="0.5.0.27-alpha" />-->
+      <PackageReference Include="engenious.ContentTool" Version="0.6.1.11-alpha" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\engenious.UI\engenious.UI.csproj" />

--- a/SampleClient/SampleGame.cs
+++ b/SampleClient/SampleGame.cs
@@ -26,6 +26,7 @@ namespace SampleClient
         {
             ScreenComponent screenComponent = new ScreenComponent(this);
             Components.Add(screenComponent);
+            engenious.UI.Control.SetScreenManager(screenComponent);
 
             screenComponent.KeyDown += (args) =>
             {

--- a/SampleClient/Screens/DragDropScreen.cs
+++ b/SampleClient/Screens/DragDropScreen.cs
@@ -14,9 +14,9 @@ namespace SampleClient.Screens
 
         private Texture2D dragIcon;
 
-        public DragDropScreen(BaseScreenComponent manager) : base(manager)
+        public DragDropScreen(BaseScreenComponent manager) : base(manager: manager)
         {
-            Button backButton = new TextButton(manager, "Back")
+            Button backButton = new TextButton("Back")
             {
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Top
@@ -26,7 +26,7 @@ namespace SampleClient.Screens
 
             dragIcon = manager.Content.Load<Texture2D>("drag");
 
-            Grid grid = new Grid(manager)
+            Grid grid = new Grid()
             {
                 Width = 600,
                 Height = 400,
@@ -40,13 +40,13 @@ namespace SampleClient.Screens
             grid.Columns.Add(new ColumnDefinition() { ResizeMode = ResizeMode.Parts, Width = 1 });
             grid.Rows.Add(new RowDefinition() { ResizeMode = ResizeMode.Parts, Height = 1 });
 
-            StackPanel buttons = new StackPanel(manager)
+            StackPanel buttons = new StackPanel()
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
             };
 
-            Button button1 = new TextButton(manager, "Button 1");
+            Button button1 = new TextButton("Button 1");
             button1.StartDrag += (sender, args) =>
             {
                 args.Handled = true;
@@ -55,8 +55,8 @@ namespace SampleClient.Screens
                 args.Icon = dragIcon;
                 args.IconSize = new Point(16, 16);
             };
-            Button button2 = new TextButton(manager, "Button 2");
-            Button button3 = new TextButton(manager, "Button 3");
+            Button button2 = new TextButton("Button 2");
+            Button button3 = new TextButton("Button 3");
             button3.StartDrag += (sender, args) =>
             {
                 args.Handled = true;
@@ -64,7 +64,7 @@ namespace SampleClient.Screens
                 args.Sender = button3;
                 args.Icon = dragIcon;
             };
-            Button button4 = new TextButton(manager, "Button 4");
+            Button button4 = new TextButton("Button 4");
             buttons.Controls.Add(button1);
             buttons.Controls.Add(button2);
             buttons.Controls.Add(button3);
@@ -72,14 +72,14 @@ namespace SampleClient.Screens
 
             grid.AddControl(buttons, 0, 0);
 
-            Panel panel = new Panel(manager)
+            Panel panel = new Panel()
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
                 Background = defaultBrush
             };
 
-            Label output = new Label(manager)
+            Label output = new Label()
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,

--- a/SampleClient/Screens/MouseCaptureScreen.cs
+++ b/SampleClient/Screens/MouseCaptureScreen.cs
@@ -11,22 +11,22 @@ namespace SampleClient.Screens
 
         private Label output;
 
-        public MouseCaptureScreen(BaseScreenComponent manager) : base(manager)
+        public MouseCaptureScreen(BaseScreenComponent manager) : base(manager: manager)
         {
             DefaultMouseMode = MouseMode.Captured;
 
             Background = new BorderBrush(Color.Green);
 
-            StackPanel stack = new StackPanel(manager);
+            StackPanel stack = new StackPanel();
             Controls.Add(stack);
 
-            Label title = new Label(manager)
+            Label title = new Label()
             {
                 TextColor = Color.White,
                 Text = "Press ESC to return to Main Screen",
             };
 
-            output = new Label(manager)
+            output = new Label()
             {
                 TextColor = Color.White,
                 Text = position.ToString(),
@@ -41,7 +41,7 @@ namespace SampleClient.Screens
             if (args.Key == Keys.Escape)
             {
                 args.Handled = true;
-                Manager.NavigateBack();
+                ScreenManager.NavigateBack();
             }
 
             base.OnKeyPress(args);

--- a/SampleClient/Screens/SplitScreen.cs
+++ b/SampleClient/Screens/SplitScreen.cs
@@ -13,11 +13,11 @@ namespace SampleClient.Screens
     {
         private Textbox textbox;
 
-        public SplitScreen(BaseScreenComponent manager) : base(manager)
+        public SplitScreen(BaseScreenComponent manager) : base(manager: manager)
         {
             Background = new BorderBrush(Color.Gray);                       //Hintergrundfarbe festlegen
 
-            Button backButton = new TextButton(manager, "Back") //Neuen TextButton erzeugen
+            Button backButton = new TextButton("Back") //Neuen TextButton erzeugen
             {
                 HorizontalAlignment = HorizontalAlignment.Left,          //Links
                 VerticalAlignment = VerticalAlignment.Top               //Oben
@@ -28,7 +28,7 @@ namespace SampleClient.Screens
 
 
             //ScrollContainer
-            ScrollContainer scrollContainer = new ScrollContainer(manager)  //Neuen ScrollContainer erzeugen
+            ScrollContainer scrollContainer = new ScrollContainer()  //Neuen ScrollContainer erzeugen
             {
                 VerticalAlignment = VerticalAlignment.Stretch,              // 100% Höhe
                 HorizontalAlignment = HorizontalAlignment.Stretch           //100% Breite
@@ -38,21 +38,21 @@ namespace SampleClient.Screens
 
 
             //Stackpanel - SubControls werden Horizontal oder Vertikal gestackt
-            StackPanel panel = new StackPanel(manager);                 //Neues Stackpanel erzeugen
+            StackPanel panel = new StackPanel();                 //Neues Stackpanel erzeugen
             panel.VerticalAlignment = VerticalAlignment.Stretch;        //100% Höhe
             scrollContainer.Content = panel;                            //Ein Scroll Container kann nur ein Control beherbergen
             panel.ControlSpacing = 20;
 
             //Label
-            Label label = new Label(manager) { Text = "Control Showcase" }; //Neues Label erzeugen
+            Label label = new Label() { Text = "Control Showcase" }; //Neues Label erzeugen
             panel.Controls.Add(label);                                      //Label zu Panel hinzufügen
 
             //Button
-            Button button = new TextButton(manager, "Dummy Button"); //Neuen TextButton erzeugen
+            Button button = new TextButton("Dummy Button"); //Neuen TextButton erzeugen
             panel.Controls.Add(button);                                 //Button zu Panel hinzufügen
 
             //Progressbar
-            ProgressBar pr = new ProgressBar(manager)                   //Neue ProgressBar erzeugen
+            ProgressBar pr = new ProgressBar()                   //Neue ProgressBar erzeugen
             {
                 Value = 80,                                            //Aktueller Wert
                 Height = 20,                                            //Höhe
@@ -61,7 +61,7 @@ namespace SampleClient.Screens
             panel.Controls.Add(pr);                                     //ProgressBar zu Panel hinzufügen
                         
             //ListBox
-            Listbox<string> list = new Listbox<string>(manager)
+            Listbox<string> list = new Listbox<string>()
             {
                 MaxHeight = 100,
                 HorizontalAlignment = HorizontalAlignment.Stretch
@@ -70,7 +70,7 @@ namespace SampleClient.Screens
             {
                 if (item == null)
                     return null;
-                return new Label(manager) { Text = item, Padding = new Border(15,5,15,5), HorizontalAlignment = HorizontalAlignment.Stretch };              //Control (Label) erstellen
+                return new Label() { Text = item, Padding = new Border(15,5,15,5), HorizontalAlignment = HorizontalAlignment.Stretch };              //Control (Label) erstellen
             };
             panel.Controls.Add(list);                                   //Liste zu Panel hinzufügen
 
@@ -83,11 +83,11 @@ namespace SampleClient.Screens
             list.Items.Add("Item 7");                                     //...
 
             //Combobox
-            Combobox<string> combobox = new Combobox<string>(manager)   //Neue Combobox erstellen
+            Combobox<string> combobox = new Combobox<string>()   //Neue Combobox erstellen
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,       //Breite
-                ButtonBrushOpen = new TextureBrush(Manager.Content.Load<Texture2D>("arrow_down"), TextureBrushMode.Stretch),
-                ButtonBrushClose = new TextureBrush(Manager.Content.Load<Texture2D>("arrow_up"), TextureBrushMode.Stretch),
+                ButtonBrushOpen = new TextureBrush(manager.Content.Load<Texture2D>("arrow_down"), TextureBrushMode.Stretch),
+                ButtonBrushClose = new TextureBrush(manager.Content.Load<Texture2D>("arrow_up"), TextureBrushMode.Stretch),
             };
 
             panel.Controls.Add(combobox);                               //Combobox zu Panel  hinzufügen
@@ -101,10 +101,10 @@ namespace SampleClient.Screens
             combobox.Items.Add("Item 7");                                     //...
 
             //Slider Value Label
-             Label labelSliderHorizontal = new Label(manager);
+             Label labelSliderHorizontal = new Label();
 
              //Horizontaler Slider
-             Slider sliderHorizontal = new Slider(manager)
+             Slider sliderHorizontal = new Slider()
              {
                  Width = 150,
                  Height = 20,
@@ -116,10 +116,10 @@ namespace SampleClient.Screens
              panel.Controls.Add(labelSliderHorizontal);
 
              //Slider Value Label
-             Label labelSliderVertical = new Label(manager);
+             Label labelSliderVertical = new Label();
 
              //Vertikaler Slider
-             Slider sliderVertical = new Slider(manager)
+             Slider sliderVertical = new Slider()
              {
                  Range = 100,
                  Height = 200,
@@ -134,19 +134,19 @@ namespace SampleClient.Screens
              labelSliderVertical.Text = "Value: " + sliderVertical.Value;
              panel.Controls.Add(labelSliderVertical);
 
-             Checkbox checkbox = new Checkbox(manager);
+             Checkbox checkbox = new Checkbox();
              panel.Controls.Add(checkbox);
 
 
              //Textbox   
-             textbox = new Textbox(manager)                      //Neue TextBox erzeugen
+             textbox = new Textbox()                      //Neue TextBox erzeugen
              {
                  HorizontalAlignment = HorizontalAlignment.Stretch,          //100% Breite,
                  MaxWidth = 200,
                  Text = "TEXTBOX!",                                      //Voreingestellter text
              };
 
-             Button clearTextbox = new TextButton(manager, "Clear Textbox");
+             Button clearTextbox = new TextButton("Clear Textbox");
              clearTextbox.LeftMouseClick += (s, e) =>
              {
                  textbox.SelectionStart = 0;
@@ -155,7 +155,7 @@ namespace SampleClient.Screens
              panel.Controls.Add(clearTextbox);
              panel.Controls.Add(textbox);                                //Textbox zu Panel hinzufügen
 
-            var but = new TextButton(manager, "Hello World");
+            var but = new TextButton("Hello World");
             but.LeftMouseClick += (e, a) =>
             {
                 var t = new Thread(() => {

--- a/SampleClient/Screens/StartScreen.cs
+++ b/SampleClient/Screens/StartScreen.cs
@@ -6,15 +6,15 @@ namespace SampleClient.Screens
 {
     internal class StartScreen : Screen
     {
-        public StartScreen(BaseScreenComponent manager) : base(manager)
+        public StartScreen(BaseScreenComponent manager) : base(manager: manager)
         {
             Background = new BorderBrush(Color.DarkRed);
 
-            StackPanel stack = new StackPanel(manager);
+            StackPanel stack = new StackPanel();
             Controls.Add(stack);
 
             // Button zur Controls Demo
-            Button controlScreenButton = new TextButton(manager, "Controls", "special");          //Button mit speziellen Style erstellen
+            Button controlScreenButton = new TextButton("Controls", "special");          //Button mit speziellen Style erstellen
             controlScreenButton.LeftMouseClick += (s, e) =>                                      //Click Event festlegen
             {
                 manager.NavigateToScreen(new SplitScreen(manager));                     //Screen wechseln
@@ -22,22 +22,22 @@ namespace SampleClient.Screens
             stack.Controls.Add(controlScreenButton);                                                   //Button zu Root hinzufügen
 
             // Button zur Mouse Capture Demo
-            Button capturedMouseButton = new TextButton(manager, "Captured Mouse", "special");
+            Button capturedMouseButton = new TextButton("Captured Mouse", "special");
             capturedMouseButton.LeftMouseClick += (s, e) => manager.NavigateToScreen(new MouseCaptureScreen(manager));
             ((TextButton) capturedMouseButton).Label.FitText = true;
             capturedMouseButton.MinHeight = 100;
             capturedMouseButton.MinWidth = 300;
             stack.Controls.Add(capturedMouseButton);
 
-            Button tabDemoScreen = new TextButton(manager, "Tab Demo", "special");
+            Button tabDemoScreen = new TextButton("Tab Demo", "special");
             tabDemoScreen.LeftMouseClick += (s, e) => manager.NavigateToScreen(new TabScreen(manager));
             stack.Controls.Add(tabDemoScreen);
 
-            Button dragDropScreen = new TextButton(manager, "Drag & Drop", "special");
+            Button dragDropScreen = new TextButton("Drag & Drop", "special");
             dragDropScreen.LeftMouseClick += (s, e) => manager.NavigateToScreen(new DragDropScreen(manager));
             stack.Controls.Add(dragDropScreen);
 
-            Button disabeldButton = new TextButton(manager, "Disabled", "special");
+            Button disabeldButton = new TextButton("Disabled", "special");
             disabeldButton.Enabled = false;
             stack.Controls.Add(disabeldButton);
         }

--- a/SampleClient/Screens/TabScreen.cs
+++ b/SampleClient/Screens/TabScreen.cs
@@ -10,15 +10,15 @@ namespace SampleClient.Screens
 {
     class TabScreen : Screen
     {
-        public TabScreen(BaseScreenComponent manager) : base(manager)
+        public TabScreen(BaseScreenComponent manager) : base(manager: manager)
         {
             //Create Tab Pages
-            TabPage tabPage = new TabPage(manager, "Tab 1");
-            TabPage tabPage2 = new TabPage(manager, "Tab 2");
-            TabPage tabPage3 = new TabPage(manager, "Tab 3");
+            TabPage tabPage = new TabPage("Tab 1");
+            TabPage tabPage2 = new TabPage("Tab 2");
+            TabPage tabPage3 = new TabPage("Tab 3");
 
             //Create Tab Control & Add Pages
-            TabControl tab = new TabControl(manager);
+            TabControl tab = new TabControl();
             tab.Pages.Add(tabPage);
             tab.Pages.Add(tabPage2);
             tab.Pages.Add(tabPage3);
@@ -26,27 +26,27 @@ namespace SampleClient.Screens
             tab.HorizontalAlignment = HorizontalAlignment.Stretch;
 
             //Add Text to Page 1
-            StackPanel panel = new StackPanel(manager);
+            StackPanel panel = new StackPanel();
             tabPage.Controls.Add(panel);
             panel.VerticalAlignment = VerticalAlignment.Stretch;
             panel.HorizontalAlignment = HorizontalAlignment.Stretch;
-            panel.Controls.Add(new Label(manager) { Text = "Content on Page 1" });
-            panel.Controls.Add(new Label(manager) { Text = "Content on Page 1\nWith new Line", WordWrap = true });
-            panel.Controls.Add(new Label(manager) { Text = "Content on Page 1\nWith new LineWrap Ohoh", LineWrap = true });
-            panel.Controls.Add(new Label(manager) { Text = "Content on Page 1 1very 2very 3very 4very 5very 6very 7very 8very 9very 10very 11very 12very 13very 14very 15very 16very 17very 18very 19very 20very 21very 22very 23very 24very 25very 26very 27very 28very 29very 30very 31very 32very 33very 34very 35very 36very 37very 38very 39very Should be wrapped BeforeLineBreak\nLineBreak :)\nAfterLine Wrap 1very 2very 3very 4very 5very 6very 7very 8very 9very 10very 11very 12very 13very 14very 15very 16very 17very 18very 19very 20very 21very 22very 23very 24very 25very 26very 27very loooooong text (For Line Wrap Testing :))", WordWrap = true });
+            panel.Controls.Add(new Label() { Text = "Content on Page 1" });
+            panel.Controls.Add(new Label() { Text = "Content on Page 1\nWith new Line", WordWrap = true });
+            panel.Controls.Add(new Label() { Text = "Content on Page 1\nWith new LineWrap Ohoh", LineWrap = true });
+            panel.Controls.Add(new Label() { Text = "Content on Page 1 1very 2very 3very 4very 5very 6very 7very 8very 9very 10very 11very 12very 13very 14very 15very 16very 17very 18very 19very 20very 21very 22very 23very 24very 25very 26very 27very 28very 29very 30very 31very 32very 33very 34very 35very 36very 37very 38very 39very Should be wrapped BeforeLineBreak\nLineBreak :)\nAfterLine Wrap 1very 2very 3very 4very 5very 6very 7very 8very 9very 10very 11very 12very 13very 14very 15very 16very 17very 18very 19very 20very 21very 22very 23very 24very 25very 26very 27very loooooong text (For Line Wrap Testing :))", WordWrap = true });
 
             //Add "Create Tab" to page 2
-            Button createPage = new TextButton(manager, "Create Tab");
+            Button createPage = new TextButton("Create Tab");
             createPage.LeftMouseClick += (s, e) =>
             {
-                TabPage page = new TabPage(manager, "NEW TAB");
-                page.Controls.Add(new Label(manager) { Text = "This is a new tab page" });
+                TabPage page = new TabPage("NEW TAB");
+                page.Controls.Add(new Label() { Text = "This is a new tab page" });
                 tab.Pages.Add(page);
             };
             tabPage2.Controls.Add(createPage);
 
             //Add "Remove this page" to page 3
-            Button removePage3 = new TextButton(manager, "Remove this Page");
+            Button removePage3 = new TextButton("Remove this Page");
             removePage3.LeftMouseClick += (s, e) =>
             {
                 tab.Pages.Remove(tabPage3);

--- a/engenious.UI/BaseScreenComponent.cs
+++ b/engenious.UI/BaseScreenComponent.cs
@@ -189,20 +189,20 @@ namespace engenious.UI
             Skin.Current = new Skin(Content);
             _batch = new SpriteBatch(GraphicsDevice);
 
-            _root = new ContainerControl(this)
+            _root = new ContainerControl(manager: this)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch
             };
 
-            Frame = new ContentControl(this)
+            Frame = new ContentControl(manager: this)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch
             };
             _root.Controls.Add(Frame);
 
-            ContainerControl screenContainer = new ContainerControl(this)
+            ContainerControl screenContainer = new ContainerControl(manager: this)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch
@@ -210,7 +210,7 @@ namespace engenious.UI
             Frame.Content = screenContainer;
             ScreenTarget = screenContainer;
 
-            _flyout = new FlyoutControl(this)
+            _flyout = new FlyoutControl(manager: this)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch

--- a/engenious.UI/Control.cs
+++ b/engenious.UI/Control.cs
@@ -13,6 +13,14 @@ namespace engenious.UI
     /// </summary>
     public abstract class Control : IControl
     {
+        /// <summary>
+        /// Set the screen manager once instead of setting 
+        /// it in every controls constructor.
+        /// Will not set screen manager of existing control instances.
+        /// </summary>
+        public static void SetScreenManager(BaseScreenComponent? screenManager) => Control.screenManager = screenManager;
+        private static BaseScreenComponent? screenManager = null;
+
         private bool _invalidDrawing;
 
         private Brush _background = null!;
@@ -156,12 +164,12 @@ namespace engenious.UI
         /// <summary>
         /// Initializes a new instance of the <see cref="Control"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Control(BaseScreenComponent manager, string style = "")
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Control(string style = "", BaseScreenComponent? manager = null)
         {
-            ScreenManager = manager ?? throw new ArgumentNullException(nameof(manager));
             Style = style;
+            ScreenManager = manager ?? screenManager ?? throw new ArgumentNullException(nameof(manager));
 
             _children = new ControlCollection(this);
             _children.OnInserted += ControlCollectionInsert;
@@ -169,7 +177,7 @@ namespace engenious.UI
             _rootPathTemp = new List<Control>();
             _rootPath = new ReverseEnumerable<Control>(_rootPathTemp);
 
-            manager.ClientSizeChanged += (s, e) =>
+            ScreenManager.ClientSizeChanged += (s, e) =>
             {
                 OnResolutionChanged();
             };

--- a/engenious.UI/Control.cs
+++ b/engenious.UI/Control.cs
@@ -13,13 +13,13 @@ namespace engenious.UI
     /// </summary>
     public abstract class Control : IControl
     {
+        private static BaseScreenComponent? _screenManager = null;
         /// <summary>
         /// Set the screen manager once instead of setting 
         /// it in every controls constructor.
         /// Will not set screen manager of existing control instances.
         /// </summary>
-        public static void SetScreenManager(BaseScreenComponent? screenManager) => Control.screenManager = screenManager;
-        private static BaseScreenComponent? screenManager = null;
+        public static void SetScreenManager(BaseScreenComponent? screenManager) => _screenManager = screenManager;
 
         private bool _invalidDrawing;
 
@@ -169,7 +169,7 @@ namespace engenious.UI
         public Control(string style = "", BaseScreenComponent? manager = null)
         {
             Style = style;
-            ScreenManager = manager ?? screenManager ?? throw new ArgumentNullException(nameof(manager));
+            ScreenManager = manager ?? _screenManager ?? throw new ArgumentNullException(nameof(manager));
 
             _children = new ControlCollection(this);
             _children.OnInserted += ControlCollectionInsert;

--- a/engenious.UI/Controls/Button.cs
+++ b/engenious.UI/Controls/Button.cs
@@ -10,17 +10,17 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Button"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Button(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Button(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             TabStop = true;
             CanFocus = true;
 
             ApplySkin(typeof(Button));
         }
-        
+
         /// <inheritdoc />
         protected override void OnKeyPress(KeyEventArgs args)
         {

--- a/engenious.UI/Controls/CanvasControl.cs
+++ b/engenious.UI/Controls/CanvasControl.cs
@@ -12,10 +12,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="CanvasControl"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public CanvasControl(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public CanvasControl(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             ApplySkin(typeof(CanvasControl));
         }

--- a/engenious.UI/Controls/Checkbox.cs
+++ b/engenious.UI/Controls/Checkbox.cs
@@ -45,9 +45,9 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Checkbox"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Checkbox(BaseScreenComponent manager, string style = "") : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Checkbox(string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
             CanFocus = true;
             TabStop = true;

--- a/engenious.UI/Controls/Combobox.cs
+++ b/engenious.UI/Controls/Combobox.cs
@@ -61,23 +61,23 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Combobox{T}"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Combobox(BaseScreenComponent manager, string style = "")
-            : this(manager,item => DefaultGenerateControl(manager, style, item), style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Combobox(string style = "", BaseScreenComponent? manager = null)
+            : this(item => DefaultGenerateControl(manager, style, item), style, manager)
         {
             
         }
         /// <summary>
         /// Initializes a new instance of the <see cref="Combobox{T}"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="templateGenerator">The template generator to use for generating shown controls for items.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Combobox(BaseScreenComponent manager, GenerateTemplateDelegate<T> templateGenerator, string style = "")
-            : base(manager, templateGenerator, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Combobox(GenerateTemplateDelegate<T> templateGenerator, string style = "", BaseScreenComponent? manager = null)
+            : base(templateGenerator, style, manager)
         { 
-            _mainControl = new ContentControl(manager)
+            _mainControl = new ContentControl(manager: manager)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
@@ -85,7 +85,7 @@ namespace engenious.UI.Controls
                 Padding = Border.All(0)
             };
 
-            var grid = new Grid(manager)
+            var grid = new Grid(manager: manager)
             {
                 //HorizontalAlignment = HorizontalAlignment.Stretch,
                 //VerticalAlignment = VerticalAlignment.Stretch,
@@ -96,14 +96,14 @@ namespace engenious.UI.Controls
             Children.Add(grid);
 
             grid.AddControl(_mainControl, 0, 0);
-            _imageControl = new Image(manager)
+            _imageControl = new Image(manager: manager)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch
             };
             grid.AddControl(_imageControl, 1, 0);
 
-            Selector = new Listbox<T>(manager);
+            Selector = new Listbox<T>(manager: manager);
             Selector.HorizontalAlignment = HorizontalAlignment.Left;
             Selector.VerticalAlignment = VerticalAlignment.Top;
             Selector.MaxHeight = 100;

--- a/engenious.UI/Controls/ContainerControl.cs
+++ b/engenious.UI/Controls/ContainerControl.cs
@@ -13,10 +13,10 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="CanvasControl"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ContainerControl(BaseScreenComponent manager, string style = "") :
-            base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ContainerControl(string style = "", BaseScreenComponent? manager = null) :
+            base(style, manager)
         {
             ApplySkin(typeof(ContainerControl));
         }

--- a/engenious.UI/Controls/ContentControl.cs
+++ b/engenious.UI/Controls/ContentControl.cs
@@ -27,10 +27,10 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentControl"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ContentControl(BaseScreenComponent manager, string style = "") :
-            base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ContentControl(string style = "", BaseScreenComponent? manager = null) :
+            base(style, manager)
         {
             ApplySkin(typeof(ContentControl));
         }

--- a/engenious.UI/Controls/FlyoutControl.cs
+++ b/engenious.UI/Controls/FlyoutControl.cs
@@ -8,9 +8,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="FlyoutControl"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        internal FlyoutControl(BaseScreenComponent manager, string style = "") : base(manager, style) {
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        internal FlyoutControl(string style = "", BaseScreenComponent? manager = null) : base(style, manager) {
             ApplySkin(typeof(FlyoutControl));
         }
 

--- a/engenious.UI/Controls/Grid.cs
+++ b/engenious.UI/Controls/Grid.cs
@@ -23,10 +23,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Grid"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Grid(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Grid(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             Columns = new List<ColumnDefinition>();
             Rows = new List<RowDefinition>();
@@ -426,7 +426,7 @@ namespace engenious.UI.Controls
         /// Gets or sets the actual width for this <see cref="ColumnDefinition"/>.
         /// </summary>
         public int ActualWidth { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the expected width for this <see cref="ColumnDefinition"/>.
         /// </summary>

--- a/engenious.UI/Controls/Image.cs
+++ b/engenious.UI/Controls/Image.cs
@@ -17,10 +17,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Image(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Image(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             ApplySkin(typeof(Image));
         }

--- a/engenious.UI/Controls/Label.cs
+++ b/engenious.UI/Controls/Label.cs
@@ -184,10 +184,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Label"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Label(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Label(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             ApplySkin(typeof(Label));
         }

--- a/engenious.UI/Controls/ListControl.cs
+++ b/engenious.UI/Controls/ListControl.cs
@@ -66,11 +66,11 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ListControl{T}"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="templateGenerator">The template generator to use for generating shown controls for items.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ListControl(BaseScreenComponent manager, GenerateTemplateDelegate<T> templateGenerator, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ListControl(GenerateTemplateDelegate<T> templateGenerator, string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             CanFocus = true;
             TabStop = true;
@@ -91,20 +91,20 @@ namespace engenious.UI.Controls
             ApplySkin(typeof(ListControl<T>));
         }
 
-        internal static Control? DefaultGenerateControl(BaseScreenComponent component, string style,T? item)
+        internal static Control? DefaultGenerateControl(BaseScreenComponent? component, string style,T? item)
         {
             if (item == null) 
                 return null;
-            return new Label(component, style) { Text = item.ToString() ?? string.Empty };
+            return new Label(style, component) { Text = item.ToString() ?? string.Empty };
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListControl{T}"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ListControl(BaseScreenComponent manager, string style = "")
-            : this(manager, item => DefaultGenerateControl(manager, style, item), style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ListControl(string style = "", BaseScreenComponent? manager = null)
+            : this(item => DefaultGenerateControl(manager, style, item), style, manager)
         {
         }
 

--- a/engenious.UI/Controls/Listbox.cs
+++ b/engenious.UI/Controls/Listbox.cs
@@ -69,19 +69,19 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Listbox{T}"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Listbox(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Listbox(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
-            ScrollContainer = new ScrollContainer(manager)
+            ScrollContainer = new ScrollContainer(manager: manager)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
             };
             Children.Add(ScrollContainer);
 
-            StackPanel = new StackPanel(manager);
+            StackPanel = new StackPanel(manager: manager);
             Orientation = Orientation.Vertical;
             ScrollContainer.Content = StackPanel;
 
@@ -94,7 +94,7 @@ namespace engenious.UI.Controls
         protected override void OnInsert(T item, int index)
         {
             Control? control = TemplateGenerator(item);
-            ContentControl wrapper = new ContentControl(ScreenManager)
+            ContentControl wrapper = new ContentControl(manager: ScreenManager)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 Content = control

--- a/engenious.UI/Controls/Panel.cs
+++ b/engenious.UI/Controls/Panel.cs
@@ -8,9 +8,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Panel"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Panel(BaseScreenComponent manager, string style = "") : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Panel(string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
             ApplySkin(typeof(Panel));
         }

--- a/engenious.UI/Controls/ProgressBar.cs
+++ b/engenious.UI/Controls/ProgressBar.cs
@@ -111,10 +111,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ProgressBar"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ProgressBar(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ProgressBar(string style = "", BaseScreenComponent? manager= null)
+            : base(style, manager)
         {
             ApplySkin(typeof(ProgressBar));
         }

--- a/engenious.UI/Controls/Screen.cs
+++ b/engenious.UI/Controls/Screen.cs
@@ -10,13 +10,8 @@
         private bool _isActiveScreen = false;
 
         /// <summary>
-        /// Gets the current <see cref="BaseScreenComponent"/>.
-        /// </summary>
-        public BaseScreenComponent Manager { get; }
-
-        /// <summary>
         /// Gets the title of this screen.
-        /// <remarks>The <see cref="Manager"/> uses this <see cref="Title"/> as the window title.</remarks>
+        /// <remarks>The <see cref="Control.ScreenManager"/> uses this <see cref="Title"/> as the window title.</remarks>
         /// </summary>
         public string Title { get; protected set; }
 
@@ -86,13 +81,12 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Screen(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Screen(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             Title = string.Empty;
-            Manager = manager;
             IsOverlay = false;
             InHistory = true;
             IsVisibleScreen = false;

--- a/engenious.UI/Controls/ScrollContainer.cs
+++ b/engenious.UI/Controls/ScrollContainer.cs
@@ -235,13 +235,13 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ScrollContainer"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public ScrollContainer(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public ScrollContainer(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
 
-            _horizontalScrollbar = new Slider(manager)
+            _horizontalScrollbar = new Slider()
             {
                 VerticalAlignment = VerticalAlignment.Bottom,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -252,7 +252,7 @@ namespace engenious.UI.Controls
                 HorizontalScrollPosition = val;
             };
 
-            _verticalScrollbar = new Slider(manager)
+            _verticalScrollbar = new Slider()
             {
                 VerticalAlignment = VerticalAlignment.Stretch,
                 HorizontalAlignment = HorizontalAlignment.Right,

--- a/engenious.UI/Controls/Slider.cs
+++ b/engenious.UI/Controls/Slider.cs
@@ -81,10 +81,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Slider"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Slider(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Slider(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             CanFocus = true;
             TabStop = true;

--- a/engenious.UI/Controls/Splitter.cs
+++ b/engenious.UI/Controls/Splitter.cs
@@ -316,10 +316,10 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Splitter"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Splitter(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Splitter(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
             CanFocus = true;
             TabStop = true;

--- a/engenious.UI/Controls/StackPanel.cs
+++ b/engenious.UI/Controls/StackPanel.cs
@@ -51,9 +51,9 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="StackPanel"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public StackPanel(BaseScreenComponent manager, string style = "") : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public StackPanel(string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
             ApplySkin(typeof(StackPanel));
         }

--- a/engenious.UI/Controls/TabControl.cs
+++ b/engenious.UI/Controls/TabControl.cs
@@ -133,15 +133,15 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="TabControl"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public TabControl(BaseScreenComponent manager, string style = "") : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public TabControl(string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
             Pages = new ItemCollection<TabPage>();
             Pages.OnInserted += OnInserted;
             Pages.OnRemove += OnRemove;
 
-            var tabControlGrid = new Grid(manager)
+            var tabControlGrid = new Grid(manager: manager)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch
@@ -152,13 +152,13 @@ namespace engenious.UI.Controls
             Content = tabControlGrid;
 
 
-            _tabListStack = new StackPanel(manager);
+            _tabListStack = new StackPanel(manager: manager);
             _tabListStack.HorizontalAlignment = HorizontalAlignment.Stretch;
             _tabListStack.Orientation = Orientation.Horizontal;
             _tabListStack.Background = TabListBackground;
             tabControlGrid.AddControl(_tabListStack, 0, 0);
 
-            _tabPage = new ContentControl(manager);
+            _tabPage = new ContentControl(manager: manager);
             _tabPage.HorizontalAlignment = HorizontalAlignment.Stretch;
             _tabPage.VerticalAlignment = VerticalAlignment.Stretch;
             _tabPage.Background = TabPageBackground;
@@ -182,7 +182,7 @@ namespace engenious.UI.Controls
         /// </summary>
         private void OnInserted(TabPage item, int index)
         {
-            Label title = new Label(ScreenManager);
+            Label title = new Label(manager: ScreenManager);
             title.Text = item.Title;
             title.Padding = Border.All(10);
             title.Background = TabBrush;

--- a/engenious.UI/Controls/TabPage.cs
+++ b/engenious.UI/Controls/TabPage.cs
@@ -13,10 +13,10 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="title">The title for this page.</param>
         /// <param name="style">The style to use for this control.</param>
-        public TabPage(BaseScreenComponent manager, string title, string style = "") : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public TabPage(string title, string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
             Title = title;
         }

--- a/engenious.UI/Controls/TextButton.cs
+++ b/engenious.UI/Controls/TextButton.cs
@@ -38,7 +38,7 @@ namespace engenious.UI.Controls
             get => Label.HorizontalTextAlignment;
             set => Label.HorizontalTextAlignment = value;
         }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="VerticalAlignment"/> of the text.
         /// </summary>
@@ -60,15 +60,18 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="TextButton"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="text">The text of this button.</param>
         /// <param name="style">The style to use for this control.</param>
-        public TextButton(BaseScreenComponent manager, string text, string style = ""): base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public TextButton(string text, string style = "", BaseScreenComponent? manager = null) : base(style, manager)
         {
-            Content = new Label(manager)
+            Content = new Label(manager: manager)
             {
-                Text = text, VerticalAlignment = VerticalAlignment.Stretch, HorizontalAlignment = HorizontalAlignment.Stretch,
-                HorizontalTextAlignment = HorizontalAlignment.Center, VerticalTextAlignment = VerticalAlignment.Center
+                Text = text,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                HorizontalTextAlignment = HorizontalAlignment.Center,
+                VerticalTextAlignment = VerticalAlignment.Center
             };
 
             ApplySkin(typeof(TextButton));

--- a/engenious.UI/Controls/Textbox.cs
+++ b/engenious.UI/Controls/Textbox.cs
@@ -96,12 +96,12 @@ namespace engenious.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="Textbox"/> class.
         /// </summary>
-        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
         /// <param name="style">The style to use for this control.</param>
-        public Textbox(BaseScreenComponent manager, string style = "")
-            : base(manager, style)
+        /// <param name="manager">The <see cref="BaseScreenComponent"/>.</param>
+        public Textbox(string style = "", BaseScreenComponent? manager = null)
+            : base(style, manager)
         {
-            _label = new Label(manager, style)
+            _label = new Label(style, manager)
             {
                 HorizontalTextAlignment = HorizontalAlignment.Left,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -110,7 +110,7 @@ namespace engenious.UI.Controls
                 DrawFocusFrame = false
             };
 
-            _scrollContainer = new ScrollContainer(manager)
+            _scrollContainer = new ScrollContainer(manager: manager)
             {
                 HorizontalScrollbarVisibility = ScrollbarVisibility.Never,
                 VerticalScrollbarVisibility = ScrollbarVisibility.Never,

--- a/engenious.UI/engenious.UI.csproj
+++ b/engenious.UI/engenious.UI.csproj
@@ -28,11 +28,11 @@
 	  <DocumentationFile>$(BaseIntermediateOutputPath)/engenious.UI.xml</DocumentationFile>
     </PropertyGroup>
 	<ItemGroup>
-        <PackageReference Include="LiCo" Version="0.1.11.10-alpha" PrivateAssets="all" />
+        <PackageReference Include="LiCo" Version="0.1.11.13-alpha" PrivateAssets="all" />
         <PackageReference Include="TextCopy" Version="4.2.1" />
         <ProjectReference Include="..\..\engenious\engenious.csproj" Condition="Exists('..\..\engenious\engenious.csproj')" />
 
-        <PackageReference Include="engenious" Version="0.6.0.4-alpha" Condition="!Exists('..\..\engenious\engenious.csproj')" />
+	    <PackageReference Include="engenious" Version="0.6.1.10-alpha" Condition="!Exists('..\..\engenious\engenious.csproj')" />
         <PackageReference Include="LitGit" Version="0.2.0.55-alpha" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
The `BaseScreenComponent` is now an optional parameter for each control.
It can bet set statically for all controls through `Control.SetScreenManager`

We might need a new engenious ui version for it, as it breaks existing code